### PR TITLE
Add rope demo scenes, scripts, and prefabs

### DIFF
--- a/UnityDemo/Assets/Resources/RopeMaterial.mat
+++ b/UnityDemo/Assets/Resources/RopeMaterial.mat
@@ -1,0 +1,20 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 8
+  m_Name: RopeMaterial
+  m_Shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
+  m_ShaderKeywords: 
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs: {}
+    m_Floats: {}
+    m_Colors:
+    - _Color: {r: 0.8, g: 0.4, b: 0.1, a: 1}

--- a/UnityDemo/Assets/Resources/RopeMaterial.mat.meta
+++ b/UnityDemo/Assets/Resources/RopeMaterial.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 43d3d78cc3f34ed1bd2547b1dfe697d5
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityDemo/Assets/Resources/RopeSegment.prefab
+++ b/UnityDemo/Assets/Resources/RopeSegment.prefab
@@ -1,0 +1,44 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1000
+GameObject:
+  m_Name: RopeSegment
+  m_Layer: 0
+  m_TagString: Untagged
+  m_IsActive: 1
+  m_Component:
+  - component: {fileID: 4000}
+  - component: {fileID: 3300}
+  - component: {fileID: 2300}
+  - component: {fileID: 1360}
+  - component: {fileID: 5400}
+--- !u!4 &4000
+Transform:
+  m_GameObject: {fileID: 1000}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Father: {fileID: 0}
+--- !u!33 &3300
+MeshFilter:
+  m_GameObject: {fileID: 1000}
+  m_Mesh: {fileID: 10208, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &2300
+MeshRenderer:
+  m_GameObject: {fileID: 1000}
+  m_Materials:
+  - {fileID: 2100000, guid: 43d3d78cc3f34ed1bd2547b1dfe697d5, type: 2}
+--- !u!136 &1360
+CapsuleCollider:
+  m_GameObject: {fileID: 1000}
+  m_IsTrigger: 0
+  m_Height: 1
+  m_Radius: 0.5
+--- !u!54 &5400
+Rigidbody:
+  m_GameObject: {fileID: 1000}
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_UseGravity: 1
+  m_IsKinematic: 0

--- a/UnityDemo/Assets/Resources/RopeSegment.prefab.meta
+++ b/UnityDemo/Assets/Resources/RopeSegment.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 6dd803e6964744fc8d45bf12b1319ac6
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityDemo/Assets/Scenes/KnotDemo.unity
+++ b/UnityDemo/Assets/Scenes/KnotDemo.unity
@@ -1,0 +1,23 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1000
+GameObject:
+  m_Name: KnotDemo
+  m_Component:
+  - component: {fileID: 4000}
+  - component: {fileID: 11400000}
+  m_Layer: 0
+  m_TagString: Untagged
+  m_IsActive: 1
+--- !u!4 &4000
+Transform:
+  m_GameObject: {fileID: 1000}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Father: {fileID: 0}
+--- !u!114 &11400000
+MonoBehaviour:
+  m_GameObject: {fileID: 1000}
+  m_Script: {fileID: 11500000, guid: 4803d417afc0473589d4395fa9d3bef9, type: 3}
+  spawnSecondRope: 1

--- a/UnityDemo/Assets/Scenes/KnotDemo.unity.meta
+++ b/UnityDemo/Assets/Scenes/KnotDemo.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 849ba3aa6c1e456da3213883614ff9c0
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityDemo/Assets/Scenes/RopeTest.unity
+++ b/UnityDemo/Assets/Scenes/RopeTest.unity
@@ -1,0 +1,23 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1000
+GameObject:
+  m_Name: RopeTest
+  m_Component:
+  - component: {fileID: 4000}
+  - component: {fileID: 11400000}
+  m_Layer: 0
+  m_TagString: Untagged
+  m_IsActive: 1
+--- !u!4 &4000
+Transform:
+  m_GameObject: {fileID: 1000}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Father: {fileID: 0}
+--- !u!114 &11400000
+MonoBehaviour:
+  m_GameObject: {fileID: 1000}
+  m_Script: {fileID: 11500000, guid: 4803d417afc0473589d4395fa9d3bef9, type: 3}
+  spawnSecondRope: 0

--- a/UnityDemo/Assets/Scenes/RopeTest.unity.meta
+++ b/UnityDemo/Assets/Scenes/RopeTest.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 9eaab9127a6c4f94a24e01e172a9a588
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityDemo/Assets/Scripts/RopeController.cs
+++ b/UnityDemo/Assets/Scripts/RopeController.cs
@@ -1,0 +1,66 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+public class RopeController : MonoBehaviour
+{
+    public Transform startPoint;
+    public Transform endPoint;
+    public GameObject segmentPrefab;
+    public int segmentCount = 20;
+    public bool autoLength = true;
+    [Range(0.1f,5f)] public float stretchLimit = 1f;
+
+    private readonly List<ConfigurableJoint> joints = new List<ConfigurableJoint>();
+
+    void Start()
+    {
+        if (segmentPrefab == null || startPoint == null || endPoint == null)
+            return;
+        BuildRope();
+    }
+
+    void BuildRope()
+    {
+        Vector3 dir = (endPoint.position - startPoint.position) / segmentCount;
+        Transform prev = startPoint;
+        for (int i = 0; i < segmentCount; i++)
+        {
+            GameObject seg = Instantiate(segmentPrefab, startPoint.position + dir * (i + 1), Quaternion.identity, transform);
+            Rigidbody rb = seg.GetComponent<Rigidbody>();
+            var joint = seg.AddComponent<ConfigurableJoint>();
+            joint.connectedBody = prev.GetComponent<Rigidbody>();
+            joint.xMotion = ConfigurableJointMotion.Limited;
+            joint.yMotion = ConfigurableJointMotion.Limited;
+            joint.zMotion = ConfigurableJointMotion.Limited;
+            joint.autoConfigureConnectedAnchor = autoLength;
+            SoftJointLimit limit = joint.linearLimit;
+            limit.limit = stretchLimit;
+            joint.linearLimit = limit;
+            joints.Add(joint);
+            prev = seg.transform;
+        }
+        var endJoint = endPoint.gameObject.AddComponent<ConfigurableJoint>();
+        endJoint.connectedBody = prev.GetComponent<Rigidbody>();
+        endJoint.autoConfigureConnectedAnchor = autoLength;
+        joints.Add(endJoint);
+    }
+
+    public void SetAutoLength(bool value)
+    {
+        autoLength = value;
+        foreach (var joint in joints)
+            joint.autoConfigureConnectedAnchor = value;
+    }
+
+    public void SetStretchLimit(float value)
+    {
+        stretchLimit = value;
+        foreach (var joint in joints)
+        {
+            SoftJointLimit limit = joint.linearLimit;
+            limit.limit = value;
+            joint.linearLimit = limit;
+        }
+    }
+}
+

--- a/UnityDemo/Assets/Scripts/RopeController.cs.meta
+++ b/UnityDemo/Assets/Scripts/RopeController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 13981729e5304e98a892ca707f5b90ec
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityDemo/Assets/Scripts/RopeDemo.cs
+++ b/UnityDemo/Assets/Scripts/RopeDemo.cs
@@ -1,0 +1,66 @@
+using UnityEngine;
+using UnityEngine.UI;
+
+public class RopeDemo : MonoBehaviour
+{
+    public bool spawnSecondRope = false;
+    private GameObject segmentPrefab;
+
+    void Awake()
+    {
+        segmentPrefab = Resources.Load<GameObject>("RopeSegment");
+    }
+
+    void Start()
+    {
+        var startA = CreateAnchor(new Vector3(-2f, 0f, 0f));
+        var endA = CreateAnchor(new Vector3(2f, 0f, 0f));
+        var ropeA = new GameObject("RopeA").AddComponent<RopeController>();
+        ropeA.segmentPrefab = segmentPrefab;
+        ropeA.startPoint = startA;
+        ropeA.endPoint = endA;
+
+        if (spawnSecondRope)
+        {
+            var startB = CreateAnchor(new Vector3(-1f, 1f, 0f));
+            var endB = CreateAnchor(new Vector3(1f, 1f, 0f));
+            var ropeB = new GameObject("RopeB").AddComponent<RopeController>();
+            ropeB.segmentPrefab = segmentPrefab;
+            ropeB.startPoint = startB;
+            ropeB.endPoint = endB;
+        }
+
+        BuildUI(ropeA);
+    }
+
+    Transform CreateAnchor(Vector3 position)
+    {
+        GameObject go = new GameObject("Anchor");
+        go.transform.position = position;
+        var rb = go.AddComponent<Rigidbody>();
+        rb.isKinematic = true;
+        return go.transform;
+    }
+
+    void BuildUI(RopeController rope)
+    {
+        var canvasGO = new GameObject("Canvas", typeof(Canvas), typeof(CanvasScaler), typeof(GraphicRaycaster));
+        var canvas = canvasGO.GetComponent<Canvas>();
+        canvas.renderMode = RenderMode.ScreenSpaceOverlay;
+
+        var toggleGO = new GameObject("AutoLengthToggle", typeof(Toggle), typeof(RectTransform));
+        toggleGO.transform.SetParent(canvasGO.transform, false);
+        var toggle = toggleGO.GetComponent<Toggle>();
+        toggle.isOn = rope.autoLength;
+        toggle.onValueChanged.AddListener(rope.SetAutoLength);
+
+        var sliderGO = new GameObject("StretchSlider", typeof(Slider), typeof(RectTransform));
+        sliderGO.transform.SetParent(canvasGO.transform, false);
+        var slider = sliderGO.GetComponent<Slider>();
+        slider.minValue = 0.1f;
+        slider.maxValue = 5f;
+        slider.value = rope.stretchLimit;
+        slider.onValueChanged.AddListener(rope.SetStretchLimit);
+    }
+}
+

--- a/UnityDemo/Assets/Scripts/RopeDemo.cs.meta
+++ b/UnityDemo/Assets/Scripts/RopeDemo.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4803d417afc0473589d4395fa9d3bef9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary
- Implement RopeController with adjustable auto-length and stretch limits
- Provide RopeDemo script to spawn ropes and UI for testing single or dual rope setups
- Add RopeSegment prefab with capsule collider and material in Resources, plus RopeTest and KnotDemo scenes

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b5a3ed4e7c8327bac0ff9e4e939779